### PR TITLE
rm dependency apsystole/log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/muhwyndhamhp/gotes-mx
 go 1.20
 
 require (
-	github.com/apsystole/log v0.3.0
 	github.com/joho/godotenv v1.5.1
 	github.com/labstack/echo/v4 v4.11.1
 	github.com/yuin/goldmark v1.5.5

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/a-h/templ v0.2.408 h1:WmXdjVjxjMJyjRg+34cgg+hRC0duDg9OJy6euZbS4ek=
 github.com/a-h/templ v0.2.408/go.mod h1:6Lfhsl3Z4/vXl7jjEjkJRCqoWDGjDnuKgzjYMDSddas=
-github.com/apsystole/log v0.3.0 h1:uES5wJvdvzL6Q4KXJt6OQnDtmPCbohFkdx6v7OpbDC4=
-github.com/apsystole/log v0.3.0/go.mod h1:BBvif4d0jOPNYgXzNLVdWE//WjefJ9Hwfy/2Y5U+SV0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/utils/routing/setup.go
+++ b/utils/routing/setup.go
@@ -3,7 +3,6 @@ package routing
 import (
 	"net/http"
 
-	"github.com/apsystole/log"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/muhwyndhamhp/gotes-mx/utils/resp"
@@ -32,7 +31,7 @@ func httpErrorHandler(err error, c echo.Context) {
 	if code != http.StatusInternalServerError {
 		_ = c.JSON(code, err)
 	} else {
-		log.Error(err)
+		c.Logger().Error(err)
 		_ = resp.HTTPServerError(c)
 	}
 }


### PR DESCRIPTION
### Goal

Remove unnecessary dependency. I guess the dependency apsystole/log could have been added mistakenly. Its functionality is specific to Google Cloud Functions and not to general-purpose logging. (I'm a maintainer of that dependency, so it's more than a random opinion.)

### Tests

I've verified that after this change, the HTTP/500 generates a usual echo-specific message:

```txt
⇨ http server started on [::]:4040
{"time":"2024-07-21T16:29:04.145911883+02:00","level":"ERROR","prefix":"echo","file":"setup.go","line":"36","message":"code=500, message=Internal Server Error"}
```
